### PR TITLE
add missing self operator

### DIFF
--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -134,7 +134,7 @@ class WriteMultipleRegistersRequest(ModbusRequest):
         self.address = address
         self.values = values or []
         if not hasattr(values, '__iter__'):
-            values = [values]
+            self.values = [values]
         self.count = len(self.values)
         self.byte_count = self.count * 2
 


### PR DESCRIPTION
The parameter values of the constructor within  class WriteMultipleRegistersRequest can specified as single value or list of values. But if a single value is given the missing self operator on line 137 leads to crash in line 138 with error: TypeError("object of type 'int' has no len()",)