### PR TITLE
Endianness now used in packing bytes

### DIFF
--- a/pymodbus/payload.py
+++ b/pymodbus/payload.py
@@ -199,7 +199,7 @@ class BinaryPayloadDecoder(object):
         :returns: An initialized PayloadDecoder
         '''
         if isinstance(registers, list): # repack into flat binary
-            payload = ''.join(pack('>H', x) for x in registers)
+            payload = ''.join(pack(endian + 'H', x) for x in registers)
             return klass(payload, endian)
         raise ParameterException('Invalid collection of registers supplied')
 


### PR DESCRIPTION
I've been chasing down a weird bug with some Modbus TCP devices. The holding registers read:

```
40001: 0000, 40002: 3fc0, 40003: 0000, 40004: 4040
```

or `[0, 16320, 0, 16448]`. This should decode to two 32-bit floats: 1.5 and 3.0. This code:

```python
from pymodbus.payload import BinaryPayloadDecoder
decoder = BinaryPayloadDecoder.fromRegisters([0, 16320, 0, 16448])
print(decoder.decode_32bit_float())
print(decoder.decode_32bit_float())
```

prints -2.984375 and 3.0. I found that this was due to a hardcoded bigendian in `BinaryPayloadDecoder.fromRegisters`. With that replaced with the `endian` variable, everything decodes properly.