### PR TITLE
Signal handlers to stop in shutdown().

### DIFF
--- a/pymodbus/server/sync.py
+++ b/pymodbus/server/sync.py
@@ -258,6 +258,15 @@ class ModbusTcpServer(SocketServer.ThreadingTCPServer):
         _logger.debug("Started thread to serve client at " + str(client))
         SocketServer.ThreadingTCPServer.process_request(self, request, client)
 
+    def shutdown(self):
+        ''' Stops the serve_forever loop.
+
+        Overridden to signal handlers to stop.
+        '''
+        for thread in self.threads:
+            thread.running = False
+        SocketServer.ThreadingTCPServer.shutdown(self)
+
     def server_close(self):
         ''' Callback for stopping the running server
         '''


### PR DESCRIPTION
`ModbusTcpServer` currently overrides `server_close` to signal its request handlers to stop processing, but doesn't do the same with `shutdown`. The result is that when running the server using `serve_forever` in another thread, and then trying to signal it to stop by calling `shutdown` from the main thread, then the `shutdown` call will block forever if there are ongoing requests, since the handler threads never finishes.

## Minimal Example

### server.py
```python
#!/usr/bin/env python
from pymodbus.server.sync import ModbusTcpServer
from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext

from threading import Thread
from time import sleep

import logging
logging.basicConfig()
log = logging.getLogger()
log.setLevel(logging.DEBUG)

context = ModbusServerContext(slaves=ModbusSlaveContext())
server = ModbusTcpServer(context=context, address=("localhost", 5020))

thread = Thread(target=server.serve_forever)
thread.start()

try:
    while thread.is_alive():
        sleep(1)
except KeyboardInterrupt:
    print("Exiting...")
    server.shutdown()
    thread.join()
```

### client.py
```python
#!/usr/bin/env python
from pymodbus.client.sync import ModbusTcpClient
from time import sleep

import logging
logging.basicConfig()
log = logging.getLogger()
log.setLevel(logging.DEBUG)

try:
    client = ModbusTcpClient("localhost", port=5020)
    client.connect()
    while True:
        client.write_coil(1, True)
        client.read_coils(1, 1)
        sleep(1)
except KeyboardInterrupt:
    client.close()
```

### Instructions
1. Run `server.py`.
2. Run `client.py`.
3. Press `Ctrl+C` in the terminal running `server.py`.
4. The server does not stop.

With this patch, `ModbusTcpServer` overrides `shutdown` to signal all handlers to stop before calling the base class implementation. The server now exits as expected.

Note that the above was just an example, where threading was not necessary. In my real use case, I had a Qt application that ran `serve_forever` in a separate thread, to avoid blocking the Qt event loop.