### PR TITLE
Fix various built-in tests.

### DIFF
--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -132,9 +132,11 @@ class WriteMultipleRegistersRequest(ModbusRequest):
         '''
         ModbusRequest.__init__(self, **kwargs)
         self.address = address
-        self.values = values or []
-        if not hasattr(values, '__iter__'):
-            self.values = [values]
+        if values is None:
+            values = []
+        elif not hasattr(values, '__iter__'):
+            values = [values]
+        self.values = values
         self.count = len(self.values)
         self.byte_count = self.count * 2
 

--- a/test/test_payload.py
+++ b/test/test_payload.py
@@ -144,7 +144,7 @@ class ModbusPayloadUtilityTests(unittest.TestCase):
         ''' Test the payload decoder reset functionality '''
         payload = [1,2,3,4]
         decoder = BinaryPayloadDecoder.fromRegisters(payload, endian=Endian.Little)
-        encoded = '\x00\x01\x00\x02\x00\x03\x00\x04'
+        encoded = '\x01\x00\x02\x00\x03\x00\x04\x00'
         self.assertEqual(encoded, decoder.decode_string(8))
 
         decoder = BinaryPayloadDecoder.fromRegisters(payload, endian=Endian.Big)


### PR DESCRIPTION
Currently, if `None` is passed in explicitly, or if values is not given,
the `values` object is correctly identified as *not* having an `__iter__`
attribute, but is incorrectly identified as being a valid register value.
This breaks `testInvalidWriteMultipleRegistersRequest`.

Solution: if we see `None`, replace this with `[]` and skip the check for
`__iter__`.

Also, in the payload tests, one tests encoding of little-endian data using a reference that is big-endian.  I don't see how that test could have passed, so it has been fixed.