### PR TITLE
Fix udp sync client

### DIFF
--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -228,7 +228,7 @@ class ModbusUdpClient(BaseModbusClient):
         try:
             family = ModbusUdpClient._get_address_family(self.host)
             self.socket = socket.socket(family, socket.SOCK_DGRAM)
-            self.settimeout(self.timeout)
+            self.socket.settimeout(self.timeout)
         except socket.error, ex:
             _logger.error('Unable to create udp socket %s' % ex)
             self.close()

--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -132,9 +132,11 @@ class WriteMultipleRegistersRequest(ModbusRequest):
         '''
         ModbusRequest.__init__(self, **kwargs)
         self.address = address
-        self.values = values or []
-        if not hasattr(values, '__iter__'):
-            self.values = [values]
+        if values is None:
+            values = []
+        elif not hasattr(values, '__iter__'):
+            values = [values]
+        self.values = values
         self.count = len(self.values)
         self.byte_count = self.count * 2
 

--- a/test/test_client_sync.py
+++ b/test/test_client_sync.py
@@ -97,7 +97,10 @@ class SynchronousClientTest(unittest.TestCase):
     def testUdpClientConnect(self):
         ''' Test the Udp client connection method'''
         with patch.object(socket, 'socket') as mock_method:
-            mock_method.return_value = object()
+            class DummySocket(object):
+                def settimeout(self, *a, **kwa):
+                    pass
+            mock_method.return_value = DummySocket()
             client = ModbusUdpClient()
             self.assertTrue(client.connect())
 

--- a/test/test_payload.py
+++ b/test/test_payload.py
@@ -144,7 +144,7 @@ class ModbusPayloadUtilityTests(unittest.TestCase):
         ''' Test the payload decoder reset functionality '''
         payload = [1,2,3,4]
         decoder = BinaryPayloadDecoder.fromRegisters(payload, endian=Endian.Little)
-        encoded = '\x00\x01\x00\x02\x00\x03\x00\x04'
+        encoded = '\x01\x00\x02\x00\x03\x00\x04\x00'
         self.assertEqual(encoded, decoder.decode_string(8))
 
         decoder = BinaryPayloadDecoder.fromRegisters(payload, endian=Endian.Big)


### PR DESCRIPTION
Noticed a persistent failing test with the UDP client, on further investigation, it seems there is a typo in the `client.sync.ModbusUdpClient` class with regards to `settimeout`; I could not see this defined anywhere in the pymodbus repository, but *did* see that `socket.socket` has a `settimeout` method, so I'm guessing that is what was meant.

This uncovered a bug in the test case, that just passed in a plain `object`, not a class with a `settimeout` method, so we fix that too.