### PR TITLE
Performance enhancements for PyModbus

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include test/modbus_mocks.py

--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -304,6 +304,8 @@ class ModbusSerialClient(BaseModbusClient):
         self.parity   = kwargs.get('parity',   Defaults.Parity)
         self.baudrate = kwargs.get('baudrate', Defaults.Baudrate)
         self.timeout  = kwargs.get('timeout',  Defaults.Timeout)
+        self._last_frame_end = 0.0
+        self._silent_interval = 3.5 * (1 + 8 + 2) / self.baudrate
 
     @staticmethod
     def __implementation(method):
@@ -333,7 +335,6 @@ class ModbusSerialClient(BaseModbusClient):
             _logger.error(msg)
             self.close()
         self._last_frame_end = time.time()
-        self._silent_interval = 3.5 * (1 + 8 + 2) / self.baudrate
         return self.socket != None
 
     def close(self):

--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -1,5 +1,6 @@
 import socket
 import serial
+import time
 
 from pymodbus.constants import Defaults
 from pymodbus.factory import ClientDecoder
@@ -331,6 +332,8 @@ class ModbusSerialClient(BaseModbusClient):
         except serial.SerialException, msg:
             _logger.error(msg)
             self.close()
+        self._last_frame_end = time.time()
+        self._silent_interval = 3.5 * (1 + 8 + 2) / self.baudrate
         return self.socket != None
 
     def close(self):
@@ -345,12 +348,20 @@ class ModbusSerialClient(BaseModbusClient):
 
         If receive buffer still holds some data then flush it.
 
+        Sleep if last send finished less than 3.5 character
+        times ago.
+
         :param request: The encoded request to send
         :return: The number of bytes written
         '''
         if not self.socket:
             raise ConnectionException(self.__str__())
         if request:
+            ts = time.time()
+            if ts < self._last_frame_end + self._silent_interval:
+                _logger.debug("will sleep to wait for 3.5 char")
+                time.sleep(self._last_frame_end + self._silent_interval - ts)
+
             try:
                 waitingbytes = self.socket.inWaiting()
                 if waitingbytes:
@@ -360,7 +371,9 @@ class ModbusSerialClient(BaseModbusClient):
             except NotImplementedError:
                 pass
 
-            return self.socket.write(request)
+            size = self.socket.write(request)
+            self._last_frame_end = time.time()
+            return size
         return 0
 
     def _recv(self, size):
@@ -371,7 +384,9 @@ class ModbusSerialClient(BaseModbusClient):
         '''
         if not self.socket:
             raise ConnectionException(self.__str__())
-        return self.socket.read(size)
+        result = self.socket.read(size)
+        self._last_frame_end = time.time()
+        return result
 
     def __str__(self):
         ''' Builds a string representation of the connection

--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -369,6 +369,8 @@ class ModbusSerialClient(BaseModbusClient):
                     result = self.socket.read(waitingbytes)
                     if _logger.isEnabledFor(logging.WARNING):
                         _logger.warning("cleanup recv buffer before send: " + " ".join([hex(ord(x)) for x in result]))
+            except AttributeError:
+                pass    # can happen with test cases using mockSocket.
             except NotImplementedError:
                 pass
 

--- a/pymodbus/interfaces.py
+++ b/pymodbus/interfaces.py
@@ -151,6 +151,14 @@ class IModbusFramer(object):
         raise NotImplementedException(
             "Method not implemented by derived class")
 
+    def getResponseSize(self, message):
+        ''' Returns expected packet size of response for this request
+
+        :returns: The expected packet size
+        '''
+        raise NotImplementedException(
+            "Method not implemented by derived class")
+
 
 class IModbusSlaveContext(object):
     '''

--- a/pymodbus/pdu.py
+++ b/pymodbus/pdu.py
@@ -106,6 +106,13 @@ class ModbusRequest(ModbusPDU):
                 (self.function_code, exception))
         return ExceptionResponse(self.function_code, exception)
 
+    def getResponseSize(self):
+        ''' Returns expected packet size of response for this request
+
+        :raises: A not implemented exception
+        '''
+        raise NotImplementedException()
+
 
 class ModbusResponse(ModbusPDU):
     ''' Base class for a modbus response PDU

--- a/pymodbus/register_read_message.py
+++ b/pymodbus/register_read_message.py
@@ -38,6 +38,13 @@ class ReadRegistersRequestBase(ModbusRequest):
         '''
         self.address, self.count = struct.unpack('>HH', data)
 
+    def getResponseSize(self):
+        ''' Returns expected packet size of response for this request
+
+        :returns: The expected packet size
+        '''
+        return 1 + 2 * self.count
+
     def __str__(self):
         ''' Returns a string representation of the instance
 

--- a/pymodbus/register_read_message.py
+++ b/pymodbus/register_read_message.py
@@ -87,7 +87,8 @@ class RegisterResponseMixin(object):
         if values is not None:
             self.registers = values
 
-    def __len__(self):
+    @property
+    def count(self):
         '''
         Return the length of the register block.
         '''
@@ -161,7 +162,7 @@ class ReadRegistersResponseBase(ModbusResponse, RegisterResponseMixin):
 
         :returns: The encoded packet
         '''
-        return '%c%s' % (len(self) * 2, self.raw_registers)
+        return '%c%s' % (self.count * 2, self.raw_registers)
 
     def decode(self, data):
         ''' Decode a register response packet
@@ -185,7 +186,7 @@ class ReadRegistersResponseBase(ModbusResponse, RegisterResponseMixin):
 
         :returns: A string representation of the instance
         '''
-        return "ReadRegisterResponse (%d)" % len(self)
+        return "ReadRegisterResponse (%d)" % self.count
 
 
 class ReadHoldingRegistersRequest(ReadRegistersRequestBase):
@@ -410,7 +411,7 @@ class ReadWriteMultipleRegistersResponse(ModbusResponse, RegisterResponseMixin):
 
         :returns: The encoded packet
         '''
-        return '%c%s' % (len(self) * 2, self.raw_registers)
+        return '%c%s' % (self.count * 2, self.raw_registers)
 
     def decode(self, data):
         ''' Decode the register response packet
@@ -431,7 +432,7 @@ class ReadWriteMultipleRegistersResponse(ModbusResponse, RegisterResponseMixin):
 
         :returns: A string representation of the instance
         '''
-        return "ReadWriteNRegisterResponse (%d)" % len(self)
+        return "ReadWriteNRegisterResponse (%d)" % self.count
 
 #---------------------------------------------------------------------------#
 # Exported symbols

--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -188,6 +188,13 @@ class WriteMultipleRegistersRequest(ModbusRequest):
         context.setValues(self.function_code, self.address, self.values)
         return WriteMultipleRegistersResponse(self.address, self.count)
 
+    def getResponseSize(self):
+        ''' Returns expected packet size of response for this request
+
+        :returns: The expected packet size
+        '''
+        return 2 + 2
+
     def __str__(self):
         ''' Returns a string representation of the instance
 

--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -61,6 +61,13 @@ class WriteSingleRegisterRequest(ModbusRequest):
         values = context.getValues(self.function_code, self.address, 1)
         return WriteSingleRegisterResponse(self.address, values[0])
 
+    def getResponseSize(self):
+        ''' Returns expected packet size of response for this request
+
+        :returns: The expected packet size
+        '''
+        return 2 + 2
+
     def __str__(self):
         ''' Returns a string representation of the instance
 


### PR DESCRIPTION
The following are attempts to try and reduce the overheads in PyModbus.

It is observed that on slow hardware (think small industrial computers running ARM CPUs) the processing overhead of calling `struct.pack`/`struct.unpack` repeatedly can easily double the time taken to read a register block.

Moreover, the construct:

```
   foo = []
   for bar in baz:
       foo.append(foobar(bar))
```

is discouraged due to its performance overheads.  The following code attempts to do the following:
- All structures are now declared in constructors ahead of time where possible
- We use lazy evaluation to decode byte arrays of register data to register values or vice versa
- The raw binary data is made available as an attribute, allowing the user to process the raw data themselves.
