### PR TITLE
Implement mask_write_register method in client mixin

### DIFF
--- a/pymodbus/client/common.py
+++ b/pymodbus/client/common.py
@@ -132,6 +132,18 @@ class ModbusClientMixin(object):
         request = ReadWriteMultipleRegistersRequest(*args, **kwargs)
         return self.execute(request)
 
+    def mask_write_register(self, *args, **kwargs):
+        '''
+
+        :param address: The address of the register to write
+        :param and_mask: The and bitmask to apply to the register address
+        :param or_mask: The or bitmask to apply to the register address
+        :param unit: The slave unit this request is targeting
+        :returns: A deferred response handle
+        '''
+        request = MaskWriteRegisterRequest(*args, **kwargs)
+        return self.execute(request)
+
 #---------------------------------------------------------------------------#
 # Exported symbols
 #---------------------------------------------------------------------------#

--- a/test/test_client_common.py
+++ b/test/test_client_common.py
@@ -3,6 +3,7 @@ import unittest
 from pymodbus.client.common import ModbusClientMixin
 from pymodbus.bit_read_message import *
 from pymodbus.bit_write_message import *
+from pymodbus.file_message import *
 from pymodbus.register_read_message import *
 from pymodbus.register_write_message import *
 
@@ -51,3 +52,4 @@ class ModbusCommonClientTests(unittest.TestCase):
         self.assertTrue(isinstance(self.client.read_holding_registers(1,1), ReadHoldingRegistersRequest))
         self.assertTrue(isinstance(self.client.read_input_registers(1,1), ReadInputRegistersRequest))
         self.assertTrue(isinstance(self.client.readwrite_registers(**arguments), ReadWriteMultipleRegistersRequest))
+        self.assertTrue(isinstance(self.client.mask_write_register(1,0,0), MaskWriteRegisterRequest))


### PR DESCRIPTION
This patch adds a mask_write_register method to the client mixin as a convenience shortcut to client.execute(MaskWriteRegisterRequest(...))