### PR TITLE
FIX: Ability to chose Endianness in fromRegisters function 

### DIFF
--- a/pymodbus/payload.py
+++ b/pymodbus/payload.py
@@ -205,7 +205,7 @@ class BinaryPayloadDecoder(object):
         :returns: An initialized PayloadDecoder
         '''
         if isinstance(registers, list): # repack into flat binary
-            payload = b''.join(pack('>H', x) for x in registers)
+            payload = b''.join(pack(endian + 'H', x) for x in registers)
             return klass(payload, endian)
         raise ParameterException('Invalid collection of registers supplied')
 


### PR DESCRIPTION
Endian should be switchable, Endian in the fromRegisters function always was Endian.Big (>)

This is correctly implemented in the master branch.