### PR TITLE
Read device info fix

### DIFF
--- a/pymodbus/mei_message.py
+++ b/pymodbus/mei_message.py
@@ -25,11 +25,11 @@ class ReadDeviceInformationRequest(ModbusRequest):
 
     The Read Device Identification interface is modeled as an address space
     composed of a set of addressable data elements. The data elements are
-    called objects and an object Id identifies them.  
+    called objects and an object Id identifies them.
     '''
     function_code = 0x2b
     sub_function_code = 0x0e
-    _rtu_frame_size = 3
+    _rtu_frame_size = 7
 
     def __init__(self, read_code=None, object_id=0x00, **kwargs):
         ''' Initializes a new instance

--- a/test/test_mei_messages.py
+++ b/test/test_mei_messages.py
@@ -3,7 +3,7 @@
 MEI Message Test Fixture
 --------------------------------
 
-This fixture tests the functionality of all the 
+This fixture tests the functionality of all the
 mei based request/response messages:
 '''
 import unittest
@@ -45,7 +45,7 @@ class ModbusMeiMessageTest(unittest.TestCase):
         control = ModbusControlBlock()
         control.Identity.VendorName  = "Company"
         control.Identity.ProductCode = "Product"
-        control.Identity.MajorMinorevision = "v2.1.12"
+        control.Identity.MajorMinorRevision = "v2.1.12"
 
         handle  = ReadDeviceInformationRequest()
         result  = handle.execute(context)
@@ -69,7 +69,7 @@ class ModbusMeiMessageTest(unittest.TestCase):
     def testReadDeviceInformationResponseEncode(self):
         ''' Test that the read fifo queue response can encode '''
         message  = '\x0e\x01\x83\x00\x00\x03'
-        message += '\x00\x07Company\x01\x07Product\x02\x07v2.1.12' 
+        message += '\x00\x07Company\x01\x07Product\x02\x07v2.1.12'
         dataset  = {
             0x00: 'Company',
             0x01: 'Product',
@@ -84,7 +84,7 @@ class ModbusMeiMessageTest(unittest.TestCase):
     def testReadDeviceInformationResponseDecode(self):
         ''' Test that the read device information response can decode '''
         message  = '\x0e\x01\x01\x00\x00\x03'
-        message += '\x00\x07Company\x01\x07Product\x02\x07v2.1.12' 
+        message += '\x00\x07Company\x01\x07Product\x02\x07v2.1.12'
         handle  = ReadDeviceInformationResponse(read_code=0x00, information=[])
         handle.decode(message)
         self.assertEqual(handle.read_code, DeviceInformation.Basic)
@@ -98,6 +98,9 @@ class ModbusMeiMessageTest(unittest.TestCase):
         message = '\x04\x2B\x0E\x01\x81\x00\x01\x01\x00\x06\x66\x6F\x6F\x62\x61\x72\xD7\x3B'
         result  = ReadDeviceInformationResponse.calculateRtuFrameSize(message)
         self.assertEqual(result, 18)
+        message = '\x00\x2B\x0E\x02\x00\x4D\x47'
+        result = ReadDeviceInformationRequest.calculateRtuFrameSize(message)
+        self.assertEqual(result, 7)
 
 
 #---------------------------------------------------------------------------#


### PR DESCRIPTION
Changed `_rtu_frame_size` from `3` to `7` to match Modbus spec.

The incorrect frame size prevented the RTU framer from decoding these requests. 

A Read Device Identification request is a total of 7 bytes when using the RTU protocol:

|   Byte   |  Field Description            |  Example  |
| :--------: |  :------------------------------ | :-----------: | 
|      0      |  Slave Address              |     0x00     | 
|      1      |  MEI Function Code      |     0x2B     |
|      2      |  MEI Type                     |     0x0E     |
|      3      |  Read Device ID Code  |     0x02     |
|      4      |  Object ID                      |     0x00     |
|      5      |  CRC-16 LSB                |     0x4D     | 
|      6      |  CRC-16 MSB               |     0x47     | 
 
I've added a test case to the `mei_message` tests to cover this, and fixed a typo in one of the other `mei_message` tests which was causing it to fail

This fix has been tested against pymodbus server, as I don't have any devices that implement the MEI functions. I've verified that the data on the wire matches the expected data per the spec.