### PR TITLE
fix ModiconPayloadDecoder __init__ fail

### DIFF
--- a/examples/contrib/modicon-payload.py
+++ b/examples/contrib/modicon-payload.py
@@ -155,13 +155,14 @@ class ModiconPayloadDecoder(object):
         second  = decoder.decode_16bit_uint()
     '''
 
-    def __init__(self, payload):
+    def __init__(self, payload, endian):
         ''' Initialize a new payload decoder
 
         :param payload: The payload to decode with
         '''
         self._payload = payload
         self._pointer = 0x00
+        self._endian = endian
 
     @staticmethod
     def fromRegisters(registers, endian=Endian.Little):


### PR DESCRIPTION
Decoder fails with a missing endian attribute, needed for struct string decode.